### PR TITLE
feat: add experimental egui desktop interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Codex CLI supports a rich set of configuration options, with preferences stored 
 
 Codex keeps a lightweight, per‑repository memory of key actions to help you recall decisions and changes in each project. Entries are written locally to `<repo>/.codex/memory/memory.jsonl` after tool use (shell exec, MCP tool calls) and patch application. The file is plain JSONL so you can search, back up, or clear it easily. See [Per‑repo memory](./docs/config.md#per-repo-memory-local) for details.
 
+The GUI also reads this file to show durable items and inject a short preamble into the first prompt.
+
 Toggle per run (TUI or exec): add `--memory off` to disable, or `--memory on` to force‑enable. You can also set `CODEX_PER_REPO_MEMORY=0|1`.
 
 Durable memory and smarter preamble
@@ -91,6 +93,25 @@ TUI: memory slash commands
 What gets logged automatically (TUI)
 - On task complete: a `summary` durable item with a compact preview of the last assistant message (kept brief).
 - On approval request: a `decision` durable item noting the request (exec/patch).
+
+### GUI (egui MVP)
+
+The Rust GUI prototype lives under `codex-rs/gui` and provides a minimal desktop window for Codex.
+
+Build and run:
+
+```shell
+cargo run -p codex-gui
+```
+
+Features:
+- Live Codex conversation with approvals and token usage
+- Right-side memory panel showing durable items and recent actions
+- Injects durable memory preamble into the first prompt
+
+Screenshots: _coming soon_
+
+Limitations: early preview with plain-text rendering and minimal styling.
 
 ---
 

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1324,9 +1324,11 @@ name = "codex-gui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "codex-common",
  "codex-core",
+ "codex-login",
  "eframe",
  "egui",
  "egui_extras",

--- a/codex-rs/gui/Cargo.toml
+++ b/codex-rs/gui/Cargo.toml
@@ -16,7 +16,9 @@ tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 uuid = { version = "1", features = ["v4", "serde"] }
+chrono = { version = "0.4", features = ["serde"] }
 
 codex-core = { package = "codex-core", path = "../core" }
 codex-common = { package = "codex-common", path = "../common" }
+codex-login = { package = "codex-login", path = "../login" }
 

--- a/codex-rs/gui/src/bridge.rs
+++ b/codex-rs/gui/src/bridge.rs
@@ -1,0 +1,56 @@
+use codex_core::config::Config;
+use codex_core::protocol::Event;
+use codex_core::protocol::EventMsg;
+use codex_core::protocol::Op;
+use codex_core::ConversationManager;
+use codex_core::NewConversation;
+use std::sync::Arc;
+use tokio::sync::mpsc::unbounded_channel;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc::UnboundedSender;
+
+/// Spawn the codex_core conversation loops and return channels for
+/// submitting Ops and receiving Events.
+pub(crate) fn spawn_bridge(
+    config: Config,
+    server: Arc<ConversationManager>,
+) -> (UnboundedSender<Op>, UnboundedReceiver<Event>) {
+    let (op_tx, mut op_rx) = unbounded_channel::<Op>();
+    let (event_tx, event_rx) = unbounded_channel::<Event>();
+
+    tokio::spawn(async move {
+        let NewConversation {
+            conversation,
+            session_configured,
+            ..
+        } = match server.new_conversation(config).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::error!("failed to initialize codex-core: {e}");
+                return;
+            }
+        };
+
+        // Forward the captured SessionConfigured event first.
+        let ev = Event {
+            id: String::new(),
+            msg: EventMsg::SessionConfigured(session_configured),
+        };
+        let _ = event_tx.send(ev);
+
+        let convo_clone = conversation.clone();
+        tokio::spawn(async move {
+            while let Some(op) = op_rx.recv().await {
+                if let Err(e) = convo_clone.submit(op).await {
+                    tracing::error!("failed to submit op: {e}");
+                }
+            }
+        });
+
+        while let Ok(ev) = conversation.next_event().await {
+            let _ = event_tx.send(ev);
+        }
+    });
+
+    (op_tx, event_rx)
+}

--- a/codex-rs/gui/src/main.rs
+++ b/codex-rs/gui/src/main.rs
@@ -1,13 +1,38 @@
+mod bridge;
+mod memory;
+
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
 use clap::Parser;
+use codex_core::config::Config;
+use codex_core::config::ConfigOverrides;
+use codex_core::protocol::AskForApproval;
+use codex_core::protocol::Event;
+use codex_core::protocol::EventMsg;
+use codex_core::protocol::Op;
+use codex_core::protocol::ReviewDecision;
+use codex_core::protocol::TokenUsage;
+use codex_core::ConversationManager;
+use codex_login::AuthManager;
 use eframe::egui;
-use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::unbounded_channel;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc::UnboundedSender;
 use tracing_subscriber::EnvFilter;
 
-#[derive(clap::ValueEnum, Clone, Debug)]
-enum MemoryToggle { On, Off, Auto }
+use memory::MemoryEntry;
+use memory::MemoryLogger;
 
-#[derive(Parser, Debug)]
+#[derive(clap::ValueEnum, Clone, Debug)]
+enum MemoryToggle {
+    On,
+    Off,
+    Auto,
+}
+
+#[derive(Parser, Debug, Clone)]
 #[command(author, version, about = "Codex GUI (egui MVP)")]
 struct Args {
     /// Working directory (repo root autodetected if omitted)
@@ -20,7 +45,6 @@ struct Args {
 }
 
 fn main() {
-    // Logging
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env().add_directive("info".parse().unwrap()))
         .try_init();
@@ -28,82 +52,381 @@ fn main() {
     let args = Args::parse();
     let native_options = eframe::NativeOptions::default();
 
-    let (tx, rx) = unbounded_channel();
-    std::thread::spawn(move || backend_thread(rx));
+    let (to_backend, from_frontend_rx) = unbounded_channel();
+    let (from_backend_tx, from_backend_rx) = unbounded_channel();
+    let args_clone = args.clone();
+    std::thread::spawn(move || backend_thread(args_clone, from_frontend_rx, from_backend_tx));
 
     let _ = eframe::run_native(
         "Codex GUI",
         native_options,
-        Box::new(|cc| Ok(Box::new(CodexGui::new(cc, args, tx)))),
+        Box::new(|cc| {
+            Ok(Box::new(CodexGui::new(
+                cc,
+                args,
+                to_backend,
+                from_backend_rx,
+            )))
+        }),
     );
-}
-
-// Placeholder backend thread – will integrate codex-core events later.
-fn backend_thread(_rx: UnboundedReceiver<FrontendMsg>) {
-    // For MVP skeleton we do nothing here.
 }
 
 #[derive(Clone, Debug)]
 enum FrontendMsg {
-    SendPrompt(String),
+    UserPrompt(String),
+    AddPref(String),
+    ApproveExec {
+        id: String,
+        decision: ReviewDecision,
+    },
+    ApprovePatch {
+        id: String,
+        decision: ReviewDecision,
+    },
+}
+
+#[derive(Debug)]
+enum BackendMsg {
+    Event(Event),
+    Memory {
+        durable: Vec<MemoryEntry>,
+        recent: Vec<MemoryEntry>,
+    },
+    Preamble(String),
+    Status {
+        model: String,
+        reasoning: String,
+        approval: AskForApproval,
+        context: Option<u64>,
+    },
+}
+
+fn should_enable_memory(args: &Args) -> bool {
+    if let Ok(v) = std::env::var("CODEX_PER_REPO_MEMORY").or_else(|_| std::env::var("CODEX_MEMORY"))
+    {
+        let v = v.to_ascii_lowercase();
+        if v == "0" || v == "off" {
+            return false;
+        }
+        if v == "1" || v == "on" {
+            return true;
+        }
+    }
+    match args.memory {
+        MemoryToggle::On => true,
+        MemoryToggle::Off => false,
+        MemoryToggle::Auto => true,
+    }
+}
+
+fn backend_thread(
+    args: Args,
+    mut rx: UnboundedReceiver<FrontendMsg>,
+    tx: UnboundedSender<BackendMsg>,
+) {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async move {
+        let overrides = ConfigOverrides { cwd: args.cwd.clone(), ..Default::default() };
+        let config = Config::load_with_cli_overrides(vec![], overrides).expect("config");
+        let auth_manager = AuthManager::shared(config.codex_home.clone(), config.preferred_auth_method);
+        let server = Arc::new(ConversationManager::new(auth_manager));
+        let (op_tx, mut event_rx) = bridge::spawn_bridge(config.clone(), server);
+
+        let _ = tx.send(BackendMsg::Status {
+            model: config.model.clone(),
+            reasoning: format!("{:?}", config.model_reasoning_effort),
+            approval: config.approval_policy,
+            context: config.model_context_window,
+        });
+
+        let mut memory_logger = if should_enable_memory(&args) {
+            Some(MemoryLogger::new(args.cwd.clone().unwrap_or_else(|| std::env::current_dir().unwrap())))
+        } else { None };
+
+        if let Some(ref ml) = memory_logger {
+            if let Some(pre) = ml.build_durable_preamble(512) {
+                let _ = tx.send(BackendMsg::Preamble(pre));
+            }
+        }
+
+        if let Some(ref ml) = memory_logger {
+            let path = ml.memory_file.clone();
+            let tx_mem = tx.clone();
+            tokio::spawn(async move {
+                loop {
+                    let (durable, recent) = memory::read_memory_items(&path, 50);
+                    let _ = tx_mem.send(BackendMsg::Memory { durable, recent });
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            });
+        }
+
+        let mut preamble_injected = false;
+        loop {
+            tokio::select! {
+                Some(ev) = event_rx.recv() => {
+                    if let EventMsg::SessionConfigured(sc) = &ev.msg {
+                        if let Some(ref mut ml) = memory_logger { ml.set_session_id(sc.session_id); }
+                    }
+                    let _ = tx.send(BackendMsg::Event(ev));
+                }
+                Some(msg) = rx.recv() => {
+                    match msg {
+                        FrontendMsg::UserPrompt(mut text) => {
+                            if !preamble_injected {
+                                if let Some(ref ml) = memory_logger {
+                                    if let Some(pre) = ml.build_durable_preamble(512) {
+                                        text = format!("{pre}\n{text}");
+                                    }
+                                }
+                                preamble_injected = true;
+                            }
+                            let items = vec![codex_core::protocol::InputItem::Text { text: text.clone() }];
+                            let _ = op_tx.send(Op::UserInput { items });
+                            let _ = op_tx.send(Op::AddToHistory { text });
+                        }
+                        FrontendMsg::AddPref(s) => { if let Some(ref ml) = memory_logger { let _ = ml.add_pref(&s); } }
+                        FrontendMsg::ApproveExec { id, decision } => { let _ = op_tx.send(Op::ExecApproval { id, decision }); }
+                        FrontendMsg::ApprovePatch { id, decision } => { let _ = op_tx.send(Op::PatchApproval { id, decision }); }
+                    }
+                }
+                else => break,
+            }
+        }
+    });
+}
+
+#[derive(Clone)]
+struct ApprovalRequest {
+    id: String,
+    kind: ApprovalKind,
+    reason: Option<String>,
+}
+
+#[derive(Clone)]
+enum ApprovalKind {
+    Exec { command: Vec<String>, cwd: PathBuf },
+    Patch { files: Vec<PathBuf> },
+}
+
+struct Status {
+    model: String,
+    reasoning: String,
+    approval: AskForApproval,
+    context: Option<u64>,
+    tokens: TokenUsage,
 }
 
 struct CodexGui {
-    args: Args,
     to_backend: UnboundedSender<FrontendMsg>,
-    // UI state
+    from_backend: UnboundedReceiver<BackendMsg>,
     prompt: String,
     transcript: Vec<String>,
-    memory_items: Vec<String>,
+    durable: Vec<MemoryEntry>,
+    recent: Vec<MemoryEntry>,
+    new_pref: String,
+    preamble: Option<String>,
+    pending: Option<ApprovalRequest>,
+    status: Status,
 }
 
 impl CodexGui {
-    fn new(_cc: &eframe::CreationContext<'_>, args: Args, to_backend: UnboundedSender<FrontendMsg>) -> Self {
-        Self { args, to_backend, prompt: String::new(), transcript: Vec::new(), memory_items: Vec::new() }
+    fn new(
+        _cc: &eframe::CreationContext<'_>,
+        _args: Args,
+        to_backend: UnboundedSender<FrontendMsg>,
+        from_backend: UnboundedReceiver<BackendMsg>,
+    ) -> Self {
+        Self {
+            to_backend,
+            from_backend,
+            prompt: String::new(),
+            transcript: Vec::new(),
+            durable: Vec::new(),
+            recent: Vec::new(),
+            new_pref: String::new(),
+            preamble: None,
+            pending: None,
+            status: Status {
+                model: String::new(),
+                reasoning: String::new(),
+                approval: AskForApproval::default(),
+                context: None,
+                tokens: TokenUsage {
+                    input_tokens: 0,
+                    cached_input_tokens: None,
+                    output_tokens: 0,
+                    reasoning_output_tokens: None,
+                    total_tokens: 0,
+                },
+            },
+        }
+    }
+
+    fn handle_event(&mut self, ev: Event) {
+        match ev.msg {
+            EventMsg::AgentMessage(m) => self.transcript.push(format!("Codex: {}", m.message)),
+            EventMsg::AgentMessageDelta(d) => {
+                if let Some(last) = self.transcript.last_mut() {
+                    last.push_str(&d.delta);
+                } else {
+                    self.transcript.push(d.delta);
+                }
+            }
+            EventMsg::AgentReasoning(r) => self.transcript.push(format!("[thinking] {}", r.text)),
+            EventMsg::TaskStarted(_) => self.transcript.push("Task started".into()),
+            EventMsg::TaskComplete(_) => self.transcript.push("Task complete".into()),
+            EventMsg::ExecApprovalRequest(req) => {
+                self.pending = Some(ApprovalRequest {
+                    id: ev.id,
+                    kind: ApprovalKind::Exec {
+                        command: req.command,
+                        cwd: req.cwd,
+                    },
+                    reason: req.reason,
+                });
+            }
+            EventMsg::ApplyPatchApprovalRequest(req) => {
+                let files = req.changes.keys().cloned().collect();
+                self.pending = Some(ApprovalRequest {
+                    id: ev.id,
+                    kind: ApprovalKind::Patch { files },
+                    reason: req.reason,
+                });
+            }
+            EventMsg::McpToolCallBegin(ev) => self.transcript.push(format!(
+                "MCP start: {}.{}",
+                ev.invocation.server, ev.invocation.tool
+            )),
+            EventMsg::McpToolCallEnd(ev) => self.transcript.push(format!(
+                "MCP end: {}.{}",
+                ev.invocation.server, ev.invocation.tool
+            )),
+            EventMsg::TokenCount(t) => self.status.tokens = t,
+            EventMsg::Error(e) => self.transcript.push(format!("Error: {}", e.message)),
+            EventMsg::SessionConfigured(_) => {}
+            _ => {}
+        }
     }
 }
 
 impl eframe::App for CodexGui {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        egui::TopBottomPanel::top("top_bar").show(ctx, |ui| {
+        while let Ok(msg) = self.from_backend.try_recv() {
+            match msg {
+                BackendMsg::Event(ev) => {
+                    self.handle_event(ev);
+                    ctx.request_repaint();
+                }
+                BackendMsg::Memory { durable, recent } => {
+                    self.durable = durable;
+                    self.recent = recent;
+                }
+                BackendMsg::Preamble(p) => {
+                    self.preamble = Some(p);
+                }
+                BackendMsg::Status {
+                    model,
+                    reasoning,
+                    approval,
+                    context,
+                } => {
+                    self.status.model = model;
+                    self.status.reasoning = reasoning;
+                    self.status.approval = approval;
+                    self.status.context = context;
+                }
+            }
+        }
+
+        egui::TopBottomPanel::top("status_bar").show(ctx, |ui| {
             ui.horizontal(|ui| {
-                ui.label("Codex GUI — MVP");
+                ui.label(format!("Model: {}", self.status.model));
                 ui.separator();
-                ui.label(format!("cwd: {}", self.args.cwd.as_ref().map(|p| p.display().to_string()).unwrap_or_else(|| "auto".into())));
+                if let Some(ctxw) = self.status.context {
+                    ui.label(format!(
+                        "Tokens: {}/{}",
+                        self.status.tokens.total_tokens, ctxw
+                    ));
+                } else {
+                    ui.label(format!("Tokens used: {}", self.status.tokens.total_tokens));
+                }
                 ui.separator();
-                ui.label(format!("memory: {:?}", self.args.memory));
+                ui.label(format!("Approval: {:?}", self.status.approval));
+                ui.separator();
+                ui.label(format!("Reasoning: {}", self.status.reasoning));
             });
         });
 
+        egui::SidePanel::right("memory_panel")
+            .resizable(true)
+            .default_width(320.0)
+            .show(ctx, |ui| {
+                ui.heading("Project Memory");
+                ui.separator();
+                ui.label("Durable:");
+                if self.durable.is_empty() {
+                    ui.label("(none)");
+                }
+                for item in &self.durable {
+                    let prefix = item.id.chars().take(8).collect::<String>();
+                    ui.label(format!("{} {}: {}", prefix, item.r#type, item.content));
+                }
+                ui.separator();
+                ui.label("Recent:");
+                if self.recent.is_empty() {
+                    ui.label("(none)");
+                }
+                for item in &self.recent {
+                    ui.label(format!("{}: {}", item.r#type, item.content));
+                }
+                ui.separator();
+                ui.horizontal(|ui| {
+                    ui.add(egui::TextEdit::singleline(&mut self.new_pref).hint_text("Add pref…"));
+                    if ui.button("Add Pref").clicked()
+                        && !self.new_pref.is_empty() {
+                            self.to_backend
+                                .send(FrontendMsg::AddPref(self.new_pref.clone()))
+                                .ok();
+                            self.new_pref.clear();
+                        }
+                });
+            });
+
         egui::TopBottomPanel::bottom("composer").show(ctx, |ui| {
-            ui.separator();
+            if let Some(pre) = &self.preamble {
+                ui.label(pre);
+                ui.separator();
+            }
             ui.label("Ask Codex:");
             let r = egui::TextEdit::multiline(&mut self.prompt)
                 .desired_rows(3)
                 .hint_text("Type a prompt…")
                 .lock_focus(true)
                 .show(ui);
-            if r.response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter) && i.modifiers.shift_only()) {
-                self.to_backend.send(FrontendMsg::SendPrompt(self.prompt.clone())).ok();
+            if r.response.lost_focus()
+                && ui.input(|i| i.key_pressed(egui::Key::Enter) && i.modifiers.shift_only())
+            {
+                self.to_backend
+                    .send(FrontendMsg::UserPrompt(self.prompt.clone()))
+                    .ok();
                 self.transcript.push(format!("You: {}", self.prompt));
                 self.prompt.clear();
+                self.preamble = None;
             }
             ui.horizontal(|ui| {
                 if ui.button("Send (Shift+Enter)").clicked() {
-                    self.to_backend.send(FrontendMsg::SendPrompt(self.prompt.clone())).ok();
+                    self.to_backend
+                        .send(FrontendMsg::UserPrompt(self.prompt.clone()))
+                        .ok();
                     self.transcript.push(format!("You: {}", self.prompt));
                     self.prompt.clear();
+                    self.preamble = None;
                 }
-                if ui.button("Clear").clicked() { self.prompt.clear(); }
+                if ui.button("Clear").clicked() {
+                    self.prompt.clear();
+                }
             });
-        });
-
-        egui::SidePanel::right("memory_panel").resizable(true).default_width(320.0).show(ctx, |ui| {
-            ui.heading("Project Memory");
-            if self.memory_items.is_empty() { ui.label("No durable items yet."); }
-            for item in &self.memory_items {
-                ui.label(item);
-            }
         });
 
         egui::CentralPanel::default().show(ctx, |ui| {
@@ -115,5 +438,78 @@ impl eframe::App for CodexGui {
                 }
             });
         });
+
+        if let Some(app) = self.pending.clone() {
+            egui::Window::new("Approval required")
+                .collapsible(false)
+                .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+                .show(ctx, |ui| {
+                    match &app.kind {
+                        ApprovalKind::Exec { command, cwd } => {
+                            ui.label(format!("Command: {}", command.join(" ")));
+                            ui.label(format!("Cwd: {}", cwd.display()));
+                        }
+                        ApprovalKind::Patch { files } => {
+                            ui.label(format!(
+                                "Files: {}",
+                                files
+                                    .iter()
+                                    .map(|f| f.display().to_string())
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            ));
+                        }
+                    }
+                    if let Some(reason) = &app.reason {
+                        ui.label(format!("Reason: {}", reason));
+                    }
+                    ui.horizontal(|ui| {
+                        if ui.button("Approve").clicked() {
+                            match &app.kind {
+                                ApprovalKind::Exec { .. } => {
+                                    self.to_backend
+                                        .send(FrontendMsg::ApproveExec {
+                                            id: app.id.clone(),
+                                            decision: ReviewDecision::Approved,
+                                        })
+                                        .ok();
+                                }
+                                ApprovalKind::Patch { .. } => {
+                                    self.to_backend
+                                        .send(FrontendMsg::ApprovePatch {
+                                            id: app.id.clone(),
+                                            decision: ReviewDecision::Approved,
+                                        })
+                                        .ok();
+                                }
+                            }
+                            self.transcript.push("System: approved".into());
+                            self.pending = None;
+                        }
+                        if ui.button("Deny").clicked() {
+                            match &app.kind {
+                                ApprovalKind::Exec { .. } => {
+                                    self.to_backend
+                                        .send(FrontendMsg::ApproveExec {
+                                            id: app.id.clone(),
+                                            decision: ReviewDecision::Denied,
+                                        })
+                                        .ok();
+                                }
+                                ApprovalKind::Patch { .. } => {
+                                    self.to_backend
+                                        .send(FrontendMsg::ApprovePatch {
+                                            id: app.id.clone(),
+                                            decision: ReviewDecision::Denied,
+                                        })
+                                        .ok();
+                                }
+                            }
+                            self.transcript.push("System: denied".into());
+                            self.pending = None;
+                        }
+                    });
+                });
+        }
     }
 }

--- a/codex-rs/gui/src/memory.rs
+++ b/codex-rs/gui/src/memory.rs
@@ -1,0 +1,233 @@
+use chrono::Utc;
+use serde_json::json;
+use std::fs::create_dir_all;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io::BufRead;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use uuid::Uuid;
+
+#[derive(Clone, Debug)]
+pub struct MemoryEntry {
+    pub id: String,
+    pub r#type: String,
+    pub content: String,
+}
+
+#[derive(Clone)]
+pub struct MemoryLogger {
+    repo_root: PathBuf,
+    memory_dir: PathBuf,
+    pub memory_file: PathBuf,
+    session_id: Option<String>,
+}
+
+impl MemoryLogger {
+    pub fn new(start_path: PathBuf) -> Self {
+        let repo_root = detect_repo_root(&start_path).unwrap_or(start_path);
+        let memory_dir = repo_root.join(".codex").join("memory");
+        let memory_file = memory_dir.join("memory.jsonl");
+        let _ = create_dir_all(&memory_dir);
+        Self {
+            repo_root,
+            memory_dir,
+            memory_file,
+            session_id: None,
+        }
+    }
+
+    pub fn set_session_id(&mut self, id: Uuid) {
+        self.session_id = Some(id.to_string());
+    }
+
+    fn write_line(&self, value: &serde_json::Value) {
+        if let Err(e) = create_dir_all(&self.memory_dir) {
+            tracing::debug!("gui memory: create_dir_all failed: {e}");
+            return;
+        }
+        match OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.memory_file)
+        {
+            Ok(mut f) => {
+                if let Ok(s) = serde_json::to_string(value) {
+                    let _ = writeln!(f, "{}", s);
+                }
+            }
+            Err(e) => tracing::debug!("gui memory: open append failed: {e}"),
+        }
+    }
+
+    pub fn add_pref(&self, text: &str) -> anyhow::Result<()> {
+        let id = Uuid::new_v4().to_string();
+        let ts = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        let value = json!({
+            "id": id,
+            "ts": ts,
+            "repo": self.repo_root.to_string_lossy(),
+            "type": "pref",
+            "content": text,
+            "tags": ["pref"],
+            "files": [],
+            "session_id": self.session_id,
+            "source": "codex-gui",
+            "metadata": {}
+        });
+        self.write_line(&value);
+        Ok(())
+    }
+
+    pub fn build_durable_preamble(&self, max_len: usize) -> Option<String> {
+        let path = self.memory_file.as_path();
+        let Ok(file) = File::open(path) else {
+            return None;
+        };
+        let reader = std::io::BufReader::new(file);
+        let mut prefs: Vec<(String, Vec<String>)> = Vec::new();
+        let mut summaries: Vec<(String, Vec<String>)> = Vec::new();
+        for line in reader.lines().flatten() {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
+                let t = v.get("type").and_then(|x| x.as_str()).unwrap_or("");
+                if t == "pref" || t == "summary" {
+                    let c = v
+                        .get("content")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let tags: Vec<String> = v
+                        .get("tags")
+                        .and_then(|x| x.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|t| t.as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    if t == "pref" {
+                        prefs.push((c, tags));
+                    } else {
+                        summaries.push((c, tags));
+                    }
+                }
+            }
+        }
+        if prefs.is_empty() && summaries.is_empty() {
+            return None;
+        }
+        let dedupe = |items: Vec<(String, Vec<String>)>, cap: usize| -> Vec<String> {
+            use std::collections::BTreeMap;
+            let mut map: BTreeMap<String, (Vec<String>, usize)> = BTreeMap::new();
+            for (c, tags) in items {
+                let key = c.to_ascii_lowercase();
+                let e = map.entry(key).or_insert((Vec::new(), 0));
+                for t in tags {
+                    if !e.0.contains(&t) {
+                        e.0.push(t);
+                    }
+                }
+                e.1 += 1;
+            }
+            let mut out: Vec<String> = map
+                .into_iter()
+                .map(|(k, (tags, cnt))| {
+                    if cnt > 1 && !tags.is_empty() {
+                        format!("{k} (tags: {} ×{cnt})", tags.join(", "))
+                    } else if !tags.is_empty() {
+                        format!("{k} (tags: {})", tags.join(", "))
+                    } else {
+                        k
+                    }
+                })
+                .collect();
+            if out.len() > cap {
+                out.truncate(cap);
+            }
+            out
+        };
+        let prefs_out = dedupe(prefs, 8);
+        let summaries_out = dedupe(summaries, 6);
+        let mut parts: Vec<String> = Vec::new();
+        if !prefs_out.is_empty() {
+            parts.push(format!(
+                "Project preferences:\n- {}",
+                prefs_out.join("\n- ")
+            ));
+        }
+        if !summaries_out.is_empty() {
+            parts.push(format!("Project facts:\n- {}", summaries_out.join("\n- ")));
+        }
+        let mut s = parts.join("\n\n");
+        if s.len() > max_len {
+            s.truncate(max_len);
+            s.push_str("\n…");
+        }
+        Some(format!("Context: The following project memory may be helpful.\n{}\nPlease follow these preferences and consider these facts.", s))
+    }
+}
+
+pub fn read_memory_items(path: &Path, limit: usize) -> (Vec<MemoryEntry>, Vec<MemoryEntry>) {
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(_) => return (vec![], vec![]),
+    };
+    let reader = std::io::BufReader::new(file);
+    let mut durable = Vec::new();
+    let mut recent = Vec::new();
+    for line in reader.lines().flatten() {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
+            let t = v
+                .get("type")
+                .and_then(|x| x.as_str())
+                .unwrap_or("")
+                .to_string();
+            let id = v
+                .get("id")
+                .and_then(|x| x.as_str())
+                .unwrap_or("")
+                .to_string();
+            let content = v
+                .get("content")
+                .and_then(|x| x.as_str())
+                .unwrap_or("")
+                .to_string();
+            match t.as_str() {
+                "pref" | "summary" | "decision" => durable.push(MemoryEntry {
+                    id,
+                    r#type: t,
+                    content,
+                }),
+                "exec" | "tool" | "change" => recent.push(MemoryEntry {
+                    id,
+                    r#type: t,
+                    content,
+                }),
+                _ => {}
+            }
+        }
+    }
+    if durable.len() > limit {
+        durable.drain(0..durable.len().saturating_sub(limit));
+    }
+    if recent.len() > limit {
+        recent.drain(0..recent.len().saturating_sub(limit));
+    }
+    (durable, recent)
+}
+
+fn detect_repo_root(start: &Path) -> Option<PathBuf> {
+    let mut cur = start.canonicalize().unwrap_or(start.to_path_buf());
+    for _ in 0..64 {
+        if cur.join(".git").exists() || cur.join(".codex").exists() {
+            return Some(cur);
+        }
+        if let Some(parent) = cur.parent() {
+            cur = parent.to_path_buf();
+        } else {
+            break;
+        }
+    }
+    None
+}


### PR DESCRIPTION
## Summary
- add `codex-gui` desktop app wired to `codex-core` events and approvals
- surface per-repo memory with durable preamble injection and pref editor
- document building and running the new GUI in README

## Testing
- `just fmt`
- `just fix -p codex-gui`
- `cargo test -p codex-gui`
- `cargo build -p codex-gui`


------
https://chatgpt.com/codex/tasks/task_e_68b3e92151a48329943d36aa409c034e